### PR TITLE
Unname unused parameters

### DIFF
--- a/src/DefineModule.cpp
+++ b/src/DefineModule.cpp
@@ -1,6 +1,6 @@
 #include "DefineModule.hpp"
 
-bool DefineModule::PushCommandList(const std::vector<MacroInformation>& Macros, const std::string& FileName, std::ostream& ErrorOutputStream) {
+bool DefineModule::PushCommandList(const std::vector<MacroInformation>& Macros, const std::string&, std::ostream&) {
 
     for(auto& Macro : Macros) {
 
@@ -21,7 +21,7 @@ bool DefineModule::PushCommandList(const std::vector<MacroInformation>& Macros, 
 
 }
 
-bool DefineModule::Proccess(std::string& Data, const std::string& FileName, std::ostream& ErrorOutputStream) {
+bool DefineModule::Proccess(std::string& Data, const std::string&, std::ostream&) {
 
     for(auto& DKV : Defines) {
         for(size_t i = 0; i < Data.size();) {
@@ -51,7 +51,7 @@ bool DefineModule::Proccess(std::string& Data, const std::string& FileName, std:
 
 }
 
-bool DefineModule::ClearCommandList(const std::string& FileName, std::ostream& ErrorOutputStream) {
+bool DefineModule::ClearCommandList(const std::string&, std::ostream&) {
     Defines.clear();
     Undefines.clear();
     return true;

--- a/src/IncludeModule.cpp
+++ b/src/IncludeModule.cpp
@@ -4,7 +4,7 @@
 #include <sstream>
 #include <algorithm>
 
-bool IncludeModule::PushCommandList(const std::vector<MacroInformation>& Macros, const std::string& FileName, std::ostream& ErrorOutputStream) {
+bool IncludeModule::PushCommandList(const std::vector<MacroInformation>& Macros, const std::string& FileName, std::ostream&) {
 
     for(auto& Macro : Macros) {
         if(Macro.Type == INCLUDE_MACRO) {
@@ -61,7 +61,7 @@ bool IncludeModule::Proccess(std::string& Data, const std::string& FileName, std
 
 }
 
-bool IncludeModule::ClearCommandList(const std::string& FileName, std::ostream& ErrorOutputStream) {
+bool IncludeModule::ClearCommandList(const std::string&, std::ostream&) {
     Includes.clear();
     return true;
 }

--- a/src/IncludeModule.cpp
+++ b/src/IncludeModule.cpp
@@ -46,7 +46,7 @@ bool IncludeModule::Proccess(std::string& Data, const std::string& FileName, std
 
             StringStream.str("");
             StringStream.clear();
-            
+
             File.close();
 
             IncludedFiles[FileName].emplace_back(Include.File);

--- a/src/preprocessor.cpp
+++ b/src/preprocessor.cpp
@@ -149,8 +149,8 @@ bool Preprocess(std::ostream& ErrorOutputStream) {
 
             for(size_t k = 0; k < MacroModules2.size(); k++) {
                 if(std::find(
-                    MacroModules2[k]->MacroCommands.begin(), 
-                    MacroModules2[k]->MacroCommands.end(), 
+                    MacroModules2[k]->MacroCommands.begin(),
+                    MacroModules2[k]->MacroCommands.end(),
                     Content.substr(i, MacroStart - i - 1))
                     != MacroModules2[k]->MacroCommands.end()
                 ) {
@@ -195,8 +195,8 @@ bool Preprocess(std::ostream& ErrorOutputStream) {
 void WriteFile(const std::string& OutputFile)
 {
     std::fstream Output(OutputFile, std::ios::out | std::ios::binary);
-    for(int i = 0; i < WotScriptFiles.size(); ++i)
+    for(auto &data : WotScriptFiles)
     {
-        Output << WotScriptFiles[i].second;
+        Output << data.second;
     }
 }


### PR DESCRIPTION
Silences a bunch of `-Wextra` warnings.
Also a bit of whitespace cleanup.